### PR TITLE
fix bug: #siphon - should pass the faultPipe

### DIFF
--- a/pipeworks.js
+++ b/pipeworks.js
@@ -169,7 +169,7 @@ Pipeworks.prototype.siphon = function() {
 
   var pipeline = new Pipeworks();
   pipeline.pipes = this.pipes;
-  pipeline.faultPipe = this.faultPipe;
+  if (this.faultPipe) pipeline.fault(this.faultPipe);
 
   pipeline.fit({ affinity: 'sink' }, function() {
     var args = Array.prototype.slice.apply(arguments);
@@ -186,7 +186,7 @@ Pipeworks.prototype.siphon = function() {
   if (args.length > 1) {
     pipeline.flow.apply(pipeline, rest);
   } else {
-    pipeline.flow.call(pipeline);
+    pipeline.flow();
   }
 
   return pipeline;

--- a/pipeworks.js
+++ b/pipeworks.js
@@ -169,6 +169,7 @@ Pipeworks.prototype.siphon = function() {
 
   var pipeline = new Pipeworks();
   pipeline.pipes = this.pipes;
+  pipeline.faultPipe = this.faultPipe;
 
   pipeline.fit({ affinity: 'sink' }, function() {
     var args = Array.prototype.slice.apply(arguments);

--- a/test/pipeworks_test.js
+++ b/test/pipeworks_test.js
@@ -174,6 +174,26 @@ describe('Pipeworks#siphon', function() {
       task.call(null, function() { check({ number: i + 1 })});
     });
   });
+
+  it('passes to newly created siphon the faultPipe', function(done) { 
+    var thrownErr = new Error('oups')
+    var ctx = {};
+    var brokenBranch = pipeworks()
+      .fit(function(context, next) {
+        process.nextTick( function() {
+          throw thrownErr;
+        })
+      })
+      .fault(function(ctx, err, next) {
+          assert.ok(err instanceof Error, 'expected passed error');
+          next(ctx)
+      });
+
+    brokenBranch.siphon(ctx, function(passedCtx) { 
+        assert( passedCtx === ctx, 'expected passed context');
+        done()
+    });
+  })
 });
 
 describe('Pipeworks#flow', function() {


### PR DESCRIPTION
When an error is thrown in any of the handlers - the flow is broken: I don't get to the last fitting, and I don't get to the fault-pipe handler.
I assumed we need to pass the faultPipe handler.

I created this branch online, then cloned it and went to add tests.
Then I saw there are more internal parts that are ignored...

Is it on purpose that it does not pass `Pipeworks#pre` and `Pipeworks#post`?

What if the user puts his end-handler with `{affinity: sink}` ? 
we'll get broken the same way...

What if the user tries to measure exec-time using `{affinity: hoist}` ? 

Any comment will be appreciated...
